### PR TITLE
feat: change dex aggregator to use normal offchain ticker

### DIFF
--- a/generator/transformer/feed_transforms.go
+++ b/generator/transformer/feed_transforms.go
@@ -14,6 +14,7 @@ import (
 	"github.com/skip-mev/connect-mmu/config"
 	"github.com/skip-mev/connect-mmu/generator/filter"
 	"github.com/skip-mev/connect-mmu/generator/types"
+	"github.com/skip-mev/connect-mmu/market-indexer/ingesters/gecko"
 )
 
 // TransformFeed is a function that performs some transformation on the given input markets.
@@ -54,7 +55,7 @@ func NormalizeBy() TransformFeed {
 					return nil, nil, err
 				}
 				newQuote := normPair.Quote
-				if feed.ProviderConfig.Name != "gecko_terminal_api" {
+				if feed.ProviderConfig.Name != gecko.ProviderName {
 					feed.ProviderConfig.NormalizeByPair = &normPair
 				}
 				feed.Ticker.CurrencyPair.Quote = newQuote

--- a/generator/transformer/feed_transforms.go
+++ b/generator/transformer/feed_transforms.go
@@ -14,7 +14,6 @@ import (
 	"github.com/skip-mev/connect-mmu/config"
 	"github.com/skip-mev/connect-mmu/generator/filter"
 	"github.com/skip-mev/connect-mmu/generator/types"
-	"github.com/skip-mev/connect-mmu/market-indexer/ingesters/gecko"
 )
 
 // TransformFeed is a function that performs some transformation on the given input markets.
@@ -55,9 +54,6 @@ func NormalizeBy() TransformFeed {
 					return nil, nil, err
 				}
 				newQuote := normPair.Quote
-				if feed.ProviderConfig.Name != gecko.ProviderName {
-					feed.ProviderConfig.NormalizeByPair = &normPair
-				}
 				feed.Ticker.CurrencyPair.Quote = newQuote
 
 				adjustPrice, ok := avgRefPrices[normPair.String()]

--- a/market-indexer/ingesters/gecko/pools.go
+++ b/market-indexer/ingesters/gecko/pools.go
@@ -198,21 +198,7 @@ func (p *PoolData) Venue() string {
 }
 
 func (p *PoolData) VenueAddress() string {
-	baseOffChain := strings.Join([]string{
-		geckoDexToConnectTickerVenue(p.Venue()),
-		p.BaseAddress(),
-	}, types.DefiTickerDelimiter)
-
-	quoteOffChain := strings.Join([]string{
-		geckoDexToConnectTickerVenue(p.Venue()),
-		p.QuoteAddress(),
-	}, types.DefiTickerDelimiter)
-
-	return strings.ToUpper(strings.Join([]string{
-		p.Attributes.Address,
-		baseOffChain,
-		quoteOffChain,
-	}, types.TickerSeparator))
+	return p.Attributes.Address
 }
 
 // Base returns the properly formated base symbol.
@@ -265,7 +251,20 @@ func (p *PoolData) ReferencePrice() (float64, error) {
 }
 
 func (p *PoolData) OffChainTicker() (string, error) {
-	return p.BaseAddress(), nil
+	targetBase, err := p.Base()
+	if err != nil {
+		return "", err
+	}
+
+	targetQuote, err := p.Quote()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ToUpper(strings.Join([]string{
+		targetBase,
+		targetQuote,
+	}, types.TickerSeparator)), nil
 }
 
 func removeTrailingNumbers(s string) string {

--- a/market-indexer/ingesters/gecko/pools.go
+++ b/market-indexer/ingesters/gecko/pools.go
@@ -261,9 +261,21 @@ func (p *PoolData) OffChainTicker() (string, error) {
 		return "", err
 	}
 
-	return strings.ToUpper(strings.Join([]string{
+	targetBaseOffchain := strings.Join([]string{
 		targetBase,
+		geckoDexToConnectTickerVenue(p.Venue()),
+		p.BaseAddress(),
+	}, types.DefiTickerDelimiter)
+
+	targetQuoteOffchain := strings.Join([]string{
 		targetQuote,
+		geckoDexToConnectTickerVenue(p.Venue()),
+		p.QuoteAddress(),
+	}, types.DefiTickerDelimiter)
+
+	return strings.ToUpper(strings.Join([]string{
+		targetBaseOffchain,
+		targetQuoteOffchain,
 	}, types.TickerSeparator)), nil
 }
 


### PR DESCRIPTION
change off chain ticker of dex pool to use normal off chain ticker format not dex style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced market data processing with enriched metadata, allowing for additional provider market details.

- **Refactor**
  - Streamlined normalization logic to consistently assign normalized currency pairs across feeds.
  - Simplified venue address retrieval and improved ticker generation with robust error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->